### PR TITLE
Fix build errors

### DIFF
--- a/.github/workflows/emoji-app.yml
+++ b/.github/workflows/emoji-app.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/emoji-app.yml
+++ b/.github/workflows/emoji-app.yml
@@ -28,7 +28,7 @@ jobs:
           ${{ runner.os }}-buildx-
 
     - name: Build with Docker Compose
-      run: docker-compose -f docker-compose.yml build
+      run: docker compose -f docker-compose.yml build
 
     - name: Generate deployment package
       run: zip -r deploy.zip . -x '*.git*'


### PR DESCRIPTION
Hello Paulo-san,

I’m one of the people who has purchased several of your AWS-related courses on Udemy. I always enjoy learning from them!

Regarding the repository used in the "Docker Mastery: Unlock the Power of Containers for Beginners" course, the workflow seems to have become a bit outdated, causing some build issues.

- Due to some outdated action versions, several warnings, like the one below, are now appearing:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, docker/setup-buildx-action@v1, actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

I initially thought this was the cause of the build errors and made some updates, but it seems that wasn’t the direct cause, so these changes aren't strictly necessary.

- I also encountered a build error because docker-compose no longer exists:

> Run docker-compose -f docker-compose.yml build
  docker-compose -f docker-compose.yml build
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/1d62189d-042e-4539-9147-6adf05d94a19.sh: line 1: docker-compose: command not found
Error: Process completed with exit code 127.

If possible, I’d appreciate it if you could merge these changes.

Thank you!